### PR TITLE
refactor: tighten stale Redis consumer cleanup logic by explicitly ex…

### DIFF
--- a/backend/src/main/java/com/kaleidoscope/backend/async/config/RedisStreamConsumerCleanupService.java
+++ b/backend/src/main/java/com/kaleidoscope/backend/async/config/RedisStreamConsumerCleanupService.java
@@ -4,6 +4,7 @@ import com.kaleidoscope.backend.async.streaming.ConsumerStreamConstants;
 import com.kaleidoscope.backend.async.streaming.StreamingConfigConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -20,6 +21,10 @@ public class RedisStreamConsumerCleanupService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
+    // Produced by RedisStreamConfig#uniqueConsumerName (example: kaleidoscope-backend-8d78f1a0278a)
+    @Qualifier("uniqueConsumerName")
+    private final String uniqueConsumerName;
+
     @Scheduled(fixedDelayString = "${async.stream.consumer-cleanup-ms:900000}")
     public void cleanupStaleConsumers() {
         String group = StreamingConfigConstants.BACKEND_CONSUMER_GROUP;
@@ -35,27 +40,40 @@ public class RedisStreamConsumerCleanupService {
                 PendingMessagesSummary summary = redisTemplate.opsForStream().pending(stream, group);
                 long pending = summary != null ? summary.getTotalPendingMessages() : 0L;
                 if (pending > 0) {
+                    // Keep conservative behavior: avoid deleting consumers while stream has pending entries.
                     continue;
                 }
 
                 redisTemplate.execute((RedisConnection connection) -> {
                     byte[] rawStream = stream.getBytes(StandardCharsets.UTF_8);
+
                     try {
                         var consumers = redisTemplate.opsForStream().consumers(stream, group);
                         if (consumers != null) {
                             for (var consumer : consumers) {
-                                // Delete consumers that don't match our current stable naming pattern
-                                if (!consumer.consumerName().contains("kaleidoscope-backend")) {
-                                    connection.streamCommands().xGroupDelConsumer(rawStream, group,
-                                            consumer.consumerName());
-                                    log.info("Deleted stale consumer stream={} group={} consumer={}",
-                                            stream, group, consumer.consumerName());
+                                String name = consumer.consumerName();
+
+                                // Only touch backend consumers.
+                                if (!name.startsWith("kaleidoscope-backend-")) {
+                                    continue;
                                 }
+
+                                // Keep current active instance consumers.
+                                if (name.startsWith(uniqueConsumerName + "-")) {
+                                    continue;
+                                }
+
+                                // Delete stale backend consumer from old instance IDs.
+                                // Using String overload for group and consumer name as per Spring Data Redis API
+                                connection.streamCommands().xGroupDelConsumer(rawStream, group, name);
+                                log.info("Deleted stale backend consumer stream={} group={} consumer={}",
+                                        stream, group, name);
                             }
                         }
                     } catch (Exception ex) {
                         log.warn("Consumer cleanup failed stream={} group={}", stream, group, ex);
                     }
+
                     return null;
                 });
             } catch (Exception ex) {


### PR DESCRIPTION
…cluding current instance and identifying via unique consumer name