### PR TITLE
fix: feed post UX — hashtag highlighting, even column bottoms, image …

### DIFF
--- a/frontend/src/app/(auth)/create-post/page.tsx
+++ b/frontend/src/app/(auth)/create-post/page.tsx
@@ -42,6 +42,7 @@ export default function CreatePostPage() {
   });
 
   const [loading, setLoading] = useState(false);
+  const [mediaUploading, setMediaUploading] = useState(false);
   const [categories, setCategories] = useState<CategorySummaryResponseDTO[]>(
     []
   );
@@ -51,6 +52,15 @@ export default function CreatePostPage() {
   const [userSearchQuery, setUserSearchQuery] = useState("");
   const [selectedLocation, setSelectedLocation] =
     useState<LocationOption | null>(null);
+
+  const hasImage = (formData.mediaDetails?.length ?? 0) > 0;
+  const isFormReady =
+    !!formData.title.trim() &&
+    !!formData.body.trim() &&
+    formData.categoryIds.length > 0 &&
+    hasImage &&
+    !mediaUploading &&
+    !loading;
 
   // Load categories on mount
   useEffect(() => {
@@ -89,6 +99,9 @@ export default function CreatePostPage() {
       formData.categoryIds.length === 0
     ) {
       return toast.error("Title, body and categories are required");
+    }
+    if (!hasImage) {
+      return toast.error("At least one image is required");
     }
     if (formData.title.length > 200) {
       return toast.error("Title must be 200 characters or less");
@@ -176,6 +189,7 @@ export default function CreatePostPage() {
             accessToken={accessToken}
             formData={formData}
             setFormData={setFormData}
+            onUploadingChange={setMediaUploading}
           />
           <TagUsers
             accessToken={accessToken}
@@ -200,13 +214,32 @@ export default function CreatePostPage() {
             >
               Cancel
             </button>
-            <button
-              type="submit"
-              disabled={loading}
-              className="flex-[2] h-12 rounded-full text-[15px] font-bold text-on-primary bg-btn-primary hover:bg-btn-primary-hover active:scale-[0.98] shadow-md shadow-navy/15 dark:shadow-cream/10 disabled:opacity-50 transition-all cursor-pointer"
-            >
-              {loading ? "Creating..." : "Create Post"}
-            </button>
+            <div className="flex-[2] flex flex-col items-stretch gap-1.5">
+              <button
+                type="submit"
+                disabled={!isFormReady}
+                className={`w-full h-12 rounded-full text-[15px] font-bold text-on-primary bg-btn-primary shadow-md shadow-navy/15 dark:shadow-cream/10 transition-all duration-300 cursor-pointer
+                  ${isFormReady
+                    ? "hover:bg-btn-primary-hover active:scale-[0.98] opacity-100 blur-none"
+                    : "opacity-40 blur-[1.5px] pointer-events-none select-none"
+                  }`}
+              >
+                {loading ? "Creating..." : mediaUploading ? "Uploading media..." : "Create Post"}
+              </button>
+              {!isFormReady && !loading && (
+                <p className="text-center text-xs text-steel/50 dark:text-sky/35 transition-opacity duration-300">
+                  {mediaUploading
+                    ? "Waiting for upload to finish…"
+                    : !hasImage
+                    ? "Add at least one image to continue"
+                    : !formData.title.trim()
+                    ? "A title is required"
+                    : !formData.body.trim()
+                    ? "Post content is required"
+                    : "Select at least one category"}
+                </p>
+              )}
+            </div>
           </div>
         </form>
       </div>

--- a/frontend/src/components/feed/PostFeedGrid.tsx
+++ b/frontend/src/components/feed/PostFeedGrid.tsx
@@ -1,7 +1,7 @@
 // src/components/feed/PostFeedGrid.tsx
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { SocialPostCard } from "@/components/feed/SocialPostCard";
@@ -24,6 +24,21 @@ interface PostFeedGridProps {
 
 const SKELETON_HEIGHTS = ["h-52", "h-72", "h-60", "h-80", "h-48", "h-64", "h-56", "h-44", "h-68", "h-76", "h-58", "h-42"];
 
+function useColumnCount(): number {
+  const [cols, setCols] = useState(2);
+  useEffect(() => {
+    const update = () => {
+      if (window.innerWidth >= 1024) setCols(4);
+      else if (window.innerWidth >= 640) setCols(3);
+      else setCols(2);
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+  return cols;
+}
+
 export function PostFeedGrid({
   isLoading,
   error,
@@ -32,6 +47,8 @@ export function PostFeedGrid({
   onPostDeleted,
   onRetry,
 }: PostFeedGridProps) {
+  const colCount = useColumnCount();
+
   if (isLoading) {
     return (
       <div className="columns-2 sm:columns-3 lg:columns-4 gap-4">
@@ -80,33 +97,41 @@ export function PostFeedGrid({
     );
   }
 
+  // Distribute posts into columns round-robin so items fill left→right
+  const columns: NormalizedPostFeedItem[][] = Array.from({ length: colCount }, () => []);
+  posts.forEach((post, i) => columns[i % colCount].push(post));
+
+  // Global index for staggered animation delay
+  let globalIndex = 0;
+
   return (
     <AnimatePresence>
-      <div className="columns-2 sm:columns-3 lg:columns-4 gap-4">
-        {posts.map((postItem, index) => {
-          const adaptedPost: Post = mapFeedItemToPost(postItem);
-
-          return (
-            <motion.div
-              key={postItem.postId}
-              className="break-inside-avoid mb-4"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              transition={{
-                duration: 0.4,
-                delay: index * 0.04,
-                ease: [0.25, 0.1, 0.25, 1],
-              }}
-            >
-              <SocialPostCard
-                post={adaptedPost}
-                accessToken={accessToken}
-                onPostDeleted={onPostDeleted}
-              />
-            </motion.div>
-          );
-        })}
+      <div className="flex items-stretch gap-4">
+        {columns.map((col, colIdx) => (
+          <div key={colIdx} className="flex flex-col flex-1 gap-4">
+            {col.map((postItem) => {
+              const adaptedPost: Post = mapFeedItemToPost(postItem);
+              const delay = globalIndex++ * 0.04;
+              return (
+                <motion.div
+                  key={postItem.postId}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.4, delay, ease: [0.25, 0.1, 0.25, 1] }}
+                >
+                  <SocialPostCard
+                    post={adaptedPost}
+                    accessToken={accessToken}
+                    onPostDeleted={onPostDeleted}
+                  />
+                </motion.div>
+              );
+            })}
+            {/* Spacer pushes all column bottoms to the same baseline */}
+            <div className="flex-1" />
+          </div>
+        ))}
       </div>
     </AnimatePresence>
   );

--- a/frontend/src/components/post/EnhancedBodyInput.tsx
+++ b/frontend/src/components/post/EnhancedBodyInput.tsx
@@ -1,6 +1,19 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+function getHighlightedHtml(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  // Zero-width space prevents last-line height collapse in the mirror div
+  const padded = escaped + '​';
+  return padded.replace(
+    /(#\w+)/g,
+    '<span style="color:#40A2D8;font-weight:700">$1</span>'
+  );
+}
 import { Hash, Type, Bold, Italic, Link, MessageSquare } from 'lucide-react';
 import { fetchHashtagSuggestions } from '@/controllers/hashtag/hashtagController'; 
 import { formatUsageCount } from '@/lib/mappers/hashtagMapper';
@@ -54,7 +67,16 @@ export default function EnhancedBodyInput({
   const [characterCount, setCharacterCount] = useState(0);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const mirrorRef = useRef<HTMLDivElement>(null);
   const hashtagTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Keep textarea height in sync with the mirror div after every value change
+  useEffect(() => {
+    const ta = textareaRef.current;
+    const mir = mirrorRef.current;
+    if (!ta || !mir) return;
+    ta.style.height = `${mir.offsetHeight}px`;
+  }, [value]);
 
   // Calculate word and character counts
   useEffect(() => {
@@ -321,6 +343,14 @@ export default function EnhancedBodyInput({
 
       {/* Textarea */}
       <div className="p-4 relative">
+        {/* Mirror div — renders hashtag-highlighted content behind the textarea */}
+        <div
+          ref={mirrorRef}
+          aria-hidden="true"
+          className="pointer-events-none text-base leading-relaxed whitespace-pre-wrap break-words text-heading"
+          style={{ minHeight: `${minRows * 24}px` }}
+          dangerouslySetInnerHTML={{ __html: getHighlightedHtml(value) }}
+        />
         <textarea
           ref={textareaRef}
           value={value}
@@ -328,8 +358,13 @@ export default function EnhancedBodyInput({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
-          className="w-full resize-none border-0 bg-transparent text-heading placeholder-steel/40 dark:placeholder-sky/30 focus:ring-0 focus:outline-none text-base leading-relaxed"
-          style={{ minHeight: `${minRows * 24}px` }}
+          className="absolute inset-x-4 top-4 w-[calc(100%-2rem)] resize-none border-0 bg-transparent placeholder-steel/40 dark:placeholder-sky/30 focus:ring-0 focus:outline-none text-base leading-relaxed overflow-hidden"
+          style={{
+            minHeight: `${minRows * 24}px`,
+            color: 'transparent',
+            caretColor: 'var(--color-heading)',
+            WebkitTextFillColor: 'transparent',
+          }}
         />
 
         {/* Hashtag suggestions */}

--- a/frontend/src/components/post/MediaUpload.tsx
+++ b/frontend/src/components/post/MediaUpload.tsx
@@ -16,12 +16,14 @@ interface Props {
   accessToken: string | null;
   formData: PostCreateRequestDTO;
   setFormData: React.Dispatch<React.SetStateAction<PostCreateRequestDTO>>;
+  onUploadingChange?: (uploading: boolean) => void;
 }
 
 export default function MediaUpload({
   accessToken,
   formData,
   setFormData,
+  onUploadingChange,
 }: Props) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [mediaPreview, setMediaPreview] = useState<string[]>([]);
@@ -62,6 +64,7 @@ export default function MediaUpload({
 
     try {
       setUploading(true);
+      onUploadingChange?.(true);
       // Get upload signatures
       const response = await generateUploadSignatureController(accessToken, {
         fileNames: files.map((f) => f.name),
@@ -117,6 +120,7 @@ export default function MediaUpload({
       }
     } finally {
       setUploading(false);
+      onUploadingChange?.(false);
     }
   };
 

--- a/frontend/src/components/ui/PostModal.tsx
+++ b/frontend/src/components/ui/PostModal.tsx
@@ -15,9 +15,13 @@ export function PostModal({ postId, isOpen, onClose, accessToken, currentUserId 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-navy/50 backdrop-blur-sm">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-navy/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
       <div
         className="relative w-full max-w-4xl max-h-[90vh] overflow-y-auto bg-cream-50 dark:bg-navy rounded-2xl shadow-2xl shadow-navy/10 dark:shadow-black/30 border border-border-default custom-scrollbar"
+        onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={onClose}


### PR DESCRIPTION
…gate, modal close on backdrop

- EnhancedBodyInput: mirror div technique for ice-blue bold #hashtag highlighting; auto-resize textarea via mirror height sync; hardcode #40A2D8 so CSS var resolves correctly inside dangerouslySetInnerHTML
- PostFeedGrid: replace CSS columns with JS round-robin flex columns so all column bottoms are flush; useColumnCount hook mirrors sm/lg breakpoints
- PostModal: close on backdrop click via stopPropagation on inner content div
- MediaUpload: expose onUploadingChange prop so parent can track upload in-flight state
- create-post page: require at least one uploaded image before form is submittable; submit button always visible but blurred/dimmed with contextual hint until all required fields (title, body, category, image) are satisfied